### PR TITLE
HA for rabbitMQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,9 +103,7 @@ During its transit inside the *smart-router*, a message will:
 
 #### Queue cleaning
 
-The smart-router will automatically destroy RabbitMQ queues when no actor has connected to it for some time.
-The queues will only be deleted for endpoints which are declared as ```QUEUEFLAG.actor``` only. Queue belonging to
-endpoints declared as ```QUEUEFLAG.endpoint``` will never be deleted.
+The smart-router will create queues which are only defined at actor level with 'x-expires' argument.
 By default, an actor's queue will be deleted 15 minutes after the last actor has been disconnected from it.
 This value configurable in the yaml properties file.
 

--- a/README.md
+++ b/README.md
@@ -103,8 +103,8 @@ During its transit inside the *smart-router*, a message will:
 
 #### Queue cleaning
 
-The smart-router will create queues which are only defined at actor level with 'x-expires' argument.
-By default, an actor's queue will be deleted 15 minutes after the last actor has been disconnected from it.
+The smart-router will create queues with 'x-expires' argument.
+By default, a queue will be deleted 15 minutes after the last actor has been disconnected from it.
 This value configurable in the yaml properties file.
 
 ### High Availability

--- a/README.md
+++ b/README.md
@@ -94,11 +94,20 @@ and will use the following queues:
 * `<actorid>` of exchange `endpointandactor` where _actorid_ is the unique id of the actors connecting to the end point
 
 During its transit inside the *smart-router*, a message will:
+
 1. be received on the endpoint
 2. routed using the corresponding route function 
 3. queued on the queue selected by the routing function
 4. dequeued and
 5. sent to an actor.
+
+#### Queue cleaning
+
+The smart-router will automatically destroy RabbitMQ queues when no actor has connected to it for some time.
+The queues will only be deleted for endpoints which are declared as ```QUEUEFLAG.actor``` only. Queue belonging to
+endpoints declared as ```QUEUEFLAG.endpoint``` will never be deleted.
+By default, an actor's queue will be deleted 15 minutes after the last actor has been disconnected from it.
+This value configurable in the yaml properties file.
 
 ### High Availability
 Internally, the *smart-router* is composed of two modules:

--- a/config/development.yaml
+++ b/config/development.yaml
@@ -8,4 +8,5 @@ https:
     pfx_path: 'path/to/pfx'
     pfx_passphrase: 'passphrase'
 
-rabbitmq_reconnect_delay: 10000
+rabbitmqReconnectDelay: 10000
+delayBeforeDeletingInactiveQueue: 900000

--- a/lib/smartrouter.js
+++ b/lib/smartrouter.js
@@ -46,13 +46,6 @@ module.exports = new JS.Class(EventEmitter, {
      * (if a real consumer reconnect on the queue).
      */
     this._consumersWaitingForUnsubscription = [];
-
-    /**
-     * When the last actor disconnects from a queue, we put the queue name here with
-     * the associated time of the disconnection. After 'delayBeforeDeletingInactiveQueue' ms,
-     * the queue will be deleted.
-     */
-    this._queuesMarkedForDeletion = {};
   },
 
   /**
@@ -109,18 +102,6 @@ module.exports = new JS.Class(EventEmitter, {
     self.amqp.on('close', function() {
       logger.info('Connection to RabbitMQ closed.');
     });
-
-    /* Cron task which destroy inactive queues. Runs every minute */
-    setInterval(function() {
-      var currentTime = new Date().getTime();
-      logger.trace('[Cron task] Time=' + currentTime + '; Queues marked for deletion: ' + JSON.stringify(self._queuesMarkedForDeletion));
-
-      for (var queueName in self._queuesMarkedForDeletion) {
-        if (currentTime - self._queuesMarkedForDeletion[queueName] > self.delayBeforeDeletingInactiveQueue) {
-          self.queueDestroy(queueName);
-        }
-      }
-    }, 60000);
   },
 
   stop: function()
@@ -268,20 +249,20 @@ module.exports = new JS.Class(EventEmitter, {
           socket.emit('hello', {});
         });
         var endpointQueue = endpointname + '/' + endpointid;
-        if (!queuebehaviour || ((queuebehaviour & QUEUEFLAG.actor) > 0)) {
-          self.queueSubscribe(actorid, socket);
-        }
-        if ((queuebehaviour & QUEUEFLAG.endpoint) > 0) {
-          self.queueSubscribe(endpointQueue, socket);
-        }
-      });
-      socket.on('disconnect', function () {
         var markForDeletion = false;
         // endpoints queues are never deleted
         if ((queuebehaviour & QUEUEFLAG.endpoint) == 0) {
           markForDeletion = true;
         }
-        self.queuesUnsubscribe(socket, markForDeletion);
+        if (!queuebehaviour || ((queuebehaviour & QUEUEFLAG.actor) > 0)) {
+          self.queueSubscribe(actorid, socket, markForDeletion);
+        }
+        if ((queuebehaviour & QUEUEFLAG.endpoint) > 0) {
+          self.queueSubscribe(endpointQueue, socket, markForDeletion);
+        }
+      });
+      socket.on('disconnect', function () {
+        self.queuesUnsubscribe(socket);
       });
       self.config.routes.forEach( function (route) {
         if (route.endpoint === '*' || route.endpoint === endpointname) {
@@ -303,16 +284,17 @@ module.exports = new JS.Class(EventEmitter, {
   },
   /**
    * queueSubscribe: subscribe to the right queue
-   *
+   * @param markForDeletion If the queue is marked for deletion, it will be deleted after having been idle
+   *                        for some time (15min by default, configurable with delayBeforeDeletingInactiveQueue property)
    */
-  queueSubscribe: function (queuename, socket) {
+  queueSubscribe: function (queuename, socket, markForDeletion) {
     logger.info(util.format('Subscribing to queue. QueueName=%s; Socket=%s', queuename, socket.id));
     var self = this;
-    if (self._queuesMarkedForDeletion[queuename]) {
-      logger.info('Client [' + queuename + '] reconnected. Queue is not marked for deletion anymore');
-      delete self._queuesMarkedForDeletion[queuename];
+    var queueArgs = {};
+    if (markForDeletion) {
+      queueArgs['x-expires'] = self.delayBeforeDeletingInactiveQueue;
     }
-    self.amqp.queue(queuename, { autoDelete: false, closeChannelOnUnsubscribe: true }, function (q) {
+    self.amqp.queue(queuename, { autoDelete: false, closeChannelOnUnsubscribe: true, arguments: queueArgs }, function (q) {
       q.bind(queuename);
       q.subscribe(function (message, headers, deliveryInfo) {
         logger.debug(util.format("Emitting '%s' from queue [%s] on socket %s", message.type, queuename, socket.id));
@@ -334,7 +316,7 @@ module.exports = new JS.Class(EventEmitter, {
    * queueUnsubscribe: unsubscribes from the queues
    *
    */
-  queuesUnsubscribe: function (socket, markForDeletion) {
+  queuesUnsubscribe: function (socket) {
     var self = this;
     socket.get('queueData', function (err, queueData) {
       if (queueData) {
@@ -348,38 +330,10 @@ module.exports = new JS.Class(EventEmitter, {
                 break;
               }
             }
-
-            self.amqp.queue(item.queue.name, { passive : true }, function(queue) {
-            })
-            .once('open', function(queueName, messageCount, consumerCount) {
-              if (consumerCount == 0 && markForDeletion) {
-                logger.info('Queue ' + queueName + ' does not have any consumer left. Will be deleted in ' +
-                             (self.delayBeforeDeletingInactiveQueue / 60 / 1000) + ' min.');
-
-                self._queuesMarkedForDeletion[item.queue.name] = new Date().getTime();
-              }
-            });
           });
         });
       }
     });
-  },
-
-  queueDestroy: function(queueName) {
-    var self = this;
-    logger.debug('Deleting queue ' + queueName);
-    self.amqp.queue(queueName, { autoDelete: false, closeChannelOnUnsubscribe: true }, function (q) {
-      q.destroy({ ifUnused: true }).addCallback(function() {
-        logger.info('Queue ' + q.name + ' has been deleted.');
-        q.close(); // Channel is not closed by amqp.js when destroying...
-        delete self._queuesMarkedForDeletion[q.name];
-      });
-    })
-    .on('error', function(err) {
-      // if the consumer has reconnected on an other smart-router instance, the queue is not deleted (because ifUnused=true)
-      console.info('The queue ' + queueName + ' has not been deleted: ' + err);
-      delete self._queuesMarkedForDeletion[queueName];
-    })
   },
 
   /**

--- a/lib/smartrouter.js
+++ b/lib/smartrouter.js
@@ -260,16 +260,11 @@ module.exports = new JS.Class(EventEmitter, {
           socket.emit('hello', {});
         });
         var endpointQueue = endpointname + '/' + endpointid;
-        var markForDeletion = false;
-        // endpoints queues are never deleted
-        if ((queuebehaviour & QUEUEFLAG.endpoint) == 0) {
-          markForDeletion = true;
-        }
         if (!queuebehaviour || ((queuebehaviour & QUEUEFLAG.actor) > 0)) {
-          self.queueSubscribe(actorid, socket, markForDeletion);
+          self.queueSubscribe(actorid, socket);
         }
         if ((queuebehaviour & QUEUEFLAG.endpoint) > 0) {
-          self.queueSubscribe(endpointQueue, socket, markForDeletion);
+          self.queueSubscribe(endpointQueue, socket);
         }
       });
       socket.on('disconnect', function () {
@@ -295,17 +290,13 @@ module.exports = new JS.Class(EventEmitter, {
   },
   /**
    * queueSubscribe: subscribe to the right queue
-   * @param markForDeletion If the queue is marked for deletion, it will be deleted after having been idle
-   *                        for some time (15min by default, configurable with delayBeforeDeletingInactiveQueue property)
+   *
    */
-  queueSubscribe: function (queuename, socket, markForDeletion) {
+  queueSubscribe: function (queuename, socket) {
     logger.info(util.format('Subscribing to queue. QueueName=%s; Socket=%s', queuename, socket.id));
     var self = this;
-    var queueArgs = {};
-    if (markForDeletion) {
-      queueArgs['x-expires'] = self.delayBeforeDeletingInactiveQueue;
-    }
-    self.amqp.queue(queuename, { autoDelete: false, closeChannelOnUnsubscribe: true, arguments: queueArgs }, function (q) {
+    self.amqp.queue(queuename, { autoDelete: false, closeChannelOnUnsubscribe: true,
+                                 arguments: { 'x-expires': self.delayBeforeDeletingInactiveQueue } }, function (q) {
       q.bind(queuename);
       q.subscribe(function (message, headers, deliveryInfo) {
         logger.debug(util.format("Emitting '%s' from queue [%s] on socket %s", message.type, queuename, socket.id));

--- a/lib/smartrouter.js
+++ b/lib/smartrouter.js
@@ -38,6 +38,14 @@ module.exports = new JS.Class(EventEmitter, {
     * Holds the Nagios responses we return for the next check.  Is replaced after each Nagios check.
     */
     this._nagiosEvents= [];
+    /**
+     * Before unsubscribing to a queue, we store the consumer data here.
+     * We will delete it only after receiving the RabbitMQ callback.
+     * Otherwise, is case of RabbitMQ error during the unsubscribe, we will have a ghost consumer
+     * which will never be removed, and will steal messages for the real consumer
+     * (if a real consumer reconnect on the queue).
+     */
+    this._consumersWaitingForUnsubscription = [];
   },
 
   /**
@@ -64,6 +72,11 @@ module.exports = new JS.Class(EventEmitter, {
     self.amqp.on('ready', function() {
       if (self.started) {
         logger.info(util.format('Reconnected to RabbitMQ at %s', config.amqp.url));
+        // If we were trying to do some unsubscriptions before the error occurred, do them now.
+        self._consumersWaitingForUnsubscription.forEach(function(item) {
+          logger.info('Reconnection: Retrying to Unsubscribe from queue ' + item.queue.name + ' for consumer=' + item.ctag);
+          item.queue.unsubscribe(item.ctag);
+        });
         return; // We already started the socket.io server, returning.
       }
 
@@ -296,8 +309,15 @@ module.exports = new JS.Class(EventEmitter, {
     socket.get('queueData', function (err, queueData) {
       if (queueData) {
         queueData.forEach(function (item) {
+          self._consumersWaitingForUnsubscription.push(item);
           item.queue.unsubscribe(item.ctag).addCallback(function () {
             logger.info(util.format('Unsubscribed from Queue [%s] for socket %s ; consumerTag=%s', item.queue.name, socket.id, item.ctag));
+            for (var i = 0; i < self._consumersWaitingForUnsubscription.length; ++i) {
+              if (self._consumersWaitingForUnsubscription[i] && self._consumersWaitingForUnsubscription[i].ctag == item.ctag) {
+                self._consumersWaitingForUnsubscription.splice(i, 1);
+                break;
+              }
+            }
           });
         });
       }
@@ -346,7 +366,7 @@ module.exports = new JS.Class(EventEmitter, {
     // First, we declare the Queue using passive arg, in order to perform checks (Queue exists + has consumers)
     this.amqp.queue(destactorid, { passive : true}, function(queue) {
     })
-    .on('error', function(err) {
+    .once('error', function(err) {
       var errMsg = util.format("The queue [%s] does not exist (%s). The following message (type='%s') *is LOST*: %s",
                                 destactorid, err, type, JSON.stringify(message));
       logger.error(errMsg);
@@ -357,7 +377,7 @@ module.exports = new JS.Class(EventEmitter, {
                                          destactorid));
       }
     })
-    .on('open', function(queueName, messageCount, consumerCount) {
+    .once('open', function(queueName, messageCount, consumerCount) {
       // If the queue exists, we publish (publishing on a non existing queue will lose the message anyway)
       if (consumerCount < 1)
       {

--- a/lib/smartrouter.js
+++ b/lib/smartrouter.js
@@ -46,6 +46,13 @@ module.exports = new JS.Class(EventEmitter, {
      * (if a real consumer reconnect on the queue).
      */
     this._consumersWaitingForUnsubscription = [];
+
+    /**
+     * When the last actor disconnects from a queue, we put the queue name here with
+     * the associated time of the disconnection. After 'delayBeforeDeletingInactiveQueue' ms,
+     * the queue will be deleted.
+     */
+    this._queuesMarkedForDeletion = {};
   },
 
   /**
@@ -58,12 +65,14 @@ module.exports = new JS.Class(EventEmitter, {
     logger.info(util.format('RabbitMQ url is set to %s', config.amqp.url));
     var self = this;
     self.config = config;
+    self.delayBeforeDeletingInactiveQueue = CONFIG.delayBeforeDeletingInactiveQueue || (15 * 60 * 1000); // 15min by default
+    logger.info('Delay before deleting inactive queues: ' + self.delayBeforeDeletingInactiveQueue);
 
-    var reconnect_delay = CONFIG.rabbitmq_reconnect_delay || 10000;
-    self.amqp = Amqp.createConnection(config.amqp, { reconnect: true, reconnectBackoffTime: reconnect_delay });
+    var reconnectDelay = CONFIG.rabbitmqReconnectDelay || 10000;
+    self.amqp = Amqp.createConnection(config.amqp, { reconnect: true, reconnectBackoffTime: reconnectDelay });
 
     self.amqp.on('error', function (err) {
-      var errMsg = util.format('Error while connecting to RabbitMQ: %s. Will try to reconnect in %s', err, reconnect_delay);
+      var errMsg = util.format('Error while connecting to RabbitMQ: %s. Will try to reconnect in %s', err, reconnectDelay);
       logger.error(errMsg);
       self._storeNagiosEvent(new NagiosCheckResponse(NagiosCheckResponseCodes.ERROR, EVENTS_CONTROLLER_SUBSYSTEM, errMsg));
       //Emit an error on the socket for the client.
@@ -100,6 +109,18 @@ module.exports = new JS.Class(EventEmitter, {
     self.amqp.on('close', function() {
       logger.info('Connection to RabbitMQ closed.');
     });
+
+    /* Cron task which destroy inactive queues. Runs every minute */
+    setInterval(function() {
+      var currentTime = new Date().getTime();
+      logger.trace('[Cron task] Time=' + currentTime + '; Queues marked for deletion: ' + JSON.stringify(self._queuesMarkedForDeletion));
+
+      for (var queueName in self._queuesMarkedForDeletion) {
+        if (currentTime - self._queuesMarkedForDeletion[queueName] > self.delayBeforeDeletingInactiveQueue) {
+          self.queueDestroy(queueName);
+        }
+      }
+    }, 60000);
   },
 
   stop: function()
@@ -255,7 +276,12 @@ module.exports = new JS.Class(EventEmitter, {
         }
       });
       socket.on('disconnect', function () {
-        self.queuesUnsubscribe(socket);
+        var markForDeletion = false;
+        // endpoints queues are never deleted
+        if ((queuebehaviour & QUEUEFLAG.endpoint) == 0) {
+          markForDeletion = true;
+        }
+        self.queuesUnsubscribe(socket, markForDeletion);
       });
       self.config.routes.forEach( function (route) {
         if (route.endpoint === '*' || route.endpoint === endpointname) {
@@ -282,15 +308,19 @@ module.exports = new JS.Class(EventEmitter, {
   queueSubscribe: function (queuename, socket) {
     logger.info(util.format('Subscribing to queue. QueueName=%s; Socket=%s', queuename, socket.id));
     var self = this;
+    if (self._queuesMarkedForDeletion[queuename]) {
+      logger.info('Client [' + queuename + '] reconnected. Queue is not marked for deletion anymore');
+      delete self._queuesMarkedForDeletion[queuename];
+    }
     self.amqp.queue(queuename, { autoDelete: false, closeChannelOnUnsubscribe: true }, function (q) {
       q.bind(queuename);
       q.subscribe(function (message, headers, deliveryInfo) {
-        logger.debug(util.format("Emiting '%s' from queue [%s] on socket %s", message.type, queuename, socket.id));
+        logger.debug(util.format("Emitting '%s' from queue [%s] on socket %s", message.type, queuename, socket.id));
         socket.emit(message.type, message.message);
       })
       .addCallback(function (ok) {
         var data = { queue: q, ctag: ok.consumerTag };
-        logger.trace(util.format('Registering consumerTag [%s] for queue [%s] in socket %s', ok.consumerTag, queuename, socket.id));
+        logger.debug(util.format('Registering consumerTag [%s] for queue [%s] in socket %s', ok.consumerTag, queuename, socket.id));
         socket.get('queueData', function (err, queueData) {
           queueData = queueData || [];
           queueData.push(data);
@@ -304,7 +334,7 @@ module.exports = new JS.Class(EventEmitter, {
    * queueUnsubscribe: unsubscribes from the queues
    *
    */
-  queuesUnsubscribe: function (socket) {
+  queuesUnsubscribe: function (socket, markForDeletion) {
     var self = this;
     socket.get('queueData', function (err, queueData) {
       if (queueData) {
@@ -318,10 +348,38 @@ module.exports = new JS.Class(EventEmitter, {
                 break;
               }
             }
+
+            self.amqp.queue(item.queue.name, { passive : true }, function(queue) {
+            })
+            .once('open', function(queueName, messageCount, consumerCount) {
+              if (consumerCount == 0 && markForDeletion) {
+                logger.info('Queue ' + queueName + ' does not have any consumer left. Will be deleted in ' +
+                             (self.delayBeforeDeletingInactiveQueue / 60 / 1000) + ' min.');
+
+                self._queuesMarkedForDeletion[item.queue.name] = new Date().getTime();
+              }
+            });
           });
         });
       }
     });
+  },
+
+  queueDestroy: function(queueName) {
+    var self = this;
+    logger.debug('Deleting queue ' + queueName);
+    self.amqp.queue(queueName, { autoDelete: false, closeChannelOnUnsubscribe: true }, function (q) {
+      q.destroy({ ifUnused: true }).addCallback(function() {
+        logger.info('Queue ' + q.name + ' has been deleted.');
+        q.close(); // Channel is not closed by amqp.js when destroying...
+        delete self._queuesMarkedForDeletion[q.name];
+      });
+    })
+    .on('error', function(err) {
+      // if the consumer has reconnected on an other smart-router instance, the queue is not deleted (because ifUnused=true)
+      console.info('The queue ' + queueName + ' has not been deleted: ' + err);
+      delete self._queuesMarkedForDeletion[queueName];
+    })
   },
 
   /**
@@ -364,7 +422,7 @@ module.exports = new JS.Class(EventEmitter, {
     qmsg.message = message;
     logger.debug(util.format("Publishing '%s' on Queue [%s]", type, destactorid));
     // First, we declare the Queue using passive arg, in order to perform checks (Queue exists + has consumers)
-    this.amqp.queue(destactorid, { passive : true}, function(queue) {
+    this.amqp.queue(destactorid, { passive : true }, function(queue) {
     })
     .once('error', function(err) {
       var errMsg = util.format("The queue [%s] does not exist (%s). The following message (type='%s') *is LOST*: %s",

--- a/lib/smartrouter.js
+++ b/lib/smartrouter.js
@@ -65,6 +65,7 @@ module.exports = new JS.Class(EventEmitter, {
     self.amqp = Amqp.createConnection(config.amqp, { reconnect: true, reconnectBackoffTime: reconnectDelay });
 
     self.amqp.on('error', function (err) {
+      self.amqpError = true;
       var errMsg = util.format('Error while connecting to RabbitMQ: %s. Will try to reconnect in %s', err, reconnectDelay);
       logger.error(errMsg);
       self._storeNagiosEvent(new NagiosCheckResponse(NagiosCheckResponseCodes.ERROR, EVENTS_CONTROLLER_SUBSYSTEM, errMsg));
@@ -72,6 +73,7 @@ module.exports = new JS.Class(EventEmitter, {
       self.emit('amqpError', new Error(errMsg));
     });
     self.amqp.on('ready', function() {
+      self.amqpError = false;
       if (self.started) {
         logger.info(util.format('Reconnected to RabbitMQ at %s', config.amqp.url));
         // If we were trying to do some unsubscriptions before the error occurred, do them now.
@@ -101,6 +103,15 @@ module.exports = new JS.Class(EventEmitter, {
     });
     self.amqp.on('close', function() {
       logger.info('Connection to RabbitMQ closed.');
+      // AMQP backoff strategy only works in case an error has occurred.
+      // So if amqp has already emitted an error, we don't try to reconnect. It is handled by amqp backoff mechanism.
+      // But in case of a HAProxy timeout, we just receive a 'close' event without any error. We don't
+      // want to wait for a future error (i.e. a client trying to send a message), because we could lose some data.
+      if (self.started && !self.amqpError)
+      {
+        logger.info('SmartRouter is still running. Trying to reconnect to RabbitMQ.');
+        self.amqp.reconnect();
+      }
     });
   },
 
@@ -108,13 +119,13 @@ module.exports = new JS.Class(EventEmitter, {
   {
     logger.info('Stopping smartrouter');
     var self = this;
+    self.started = false;
     self.io.server.close();
     self.io.server.once('close', function () {
       logger.debug('socket server closed');
       self.amqp.end();
     });
     self.amqp.once('close', function () {
-      self.started = false;
       self.emit('stopped');
     });
   },

--- a/test/smartrouter_error_test.js
+++ b/test/smartrouter_error_test.js
@@ -34,7 +34,7 @@ describe('SmartRouter Error cases', function ()
              });
   afterEach(function (done)
             {
-              CONFIG.rabbitmq_reconnect_delay = 10000;
+              CONFIG.rabbitmqReconnectDelay = 10000;
               utils.stopSmartRouter(logger, smartrouter, done);
             });
 
@@ -146,7 +146,7 @@ describe('SmartRouter Error cases', function ()
       var myConfig = JSON.parse(JSON.stringify(smConfig));
       myConfig.amqp =  { url: 'amqp://mynock.toto.fr' };
       //We change this to not wait 3 plombes
-      CONFIG.rabbitmq_reconnect_delay = 100;
+      CONFIG.rabbitmqReconnectDelay = 100;
       correctSmartRouter.start(myConfig);
       //Now let's set the correct url
       correctSmartRouter.amqp.setOptions(smConfig.amqp);

--- a/test/smartrouter_test.js
+++ b/test/smartrouter_test.js
@@ -320,49 +320,6 @@ describe('Smartrouter tests.', function ()
     });
   });
 
-  it('should set client queue as markedForDeletion after client disconnect', function (done)
-  {
-    logger.debug('********************************************************************');
-    logger.debug('STARTING TEST "Mark actor queues for deletion after they disconnect"');
-    logger.debug('********************************************************************');
-    var mockedAgent = new Agent('http://localhost:' + config.port.toString(), 'agent/456', 'agent456', clientsParams);
-    var mockedUI = new UI('http://localhost:' + config.port.toString(), 'ui/456', 'ui456', clientsParams);
-    mockedAgent.connect();
-    mockedUI.connect();
-    mockedUI.socket.once('disconnect', function () // clients are disconnected automatically after 200ms
-    {
-      // We wait 200ms to be sure we have unsubscribed from RabbitMQ and we test which queue is marked for deletion.
-      setTimeout(function() {
-        console.log(smartrouter._queuesMarkedForDeletion);
-        assert.isDefined(smartrouter._queuesMarkedForDeletion['ui/456/ui456']);
-        assert.isUndefined(smartrouter._queuesMarkedForDeletion['agent/456/agent456']); // Endpoints queues are not deleted.
-        done();
-      }, 200);
-    });
-  });
-
-  it('should delete a queue in RabbitMQ', function (done)
-  {
-    logger.debug('******************************************');
-    logger.debug('STARTING TEST "Delete a Queue in RabbitMQ"');
-    logger.debug('******************************************');
-    var queueName = 'test_queue';
-    smartrouter.amqp.queue(queueName, { autoDelete: false, closeChannelOnUnsubscribe: true }, function (q) {
-    })
-    .on('open', function() {
-      smartrouter.queueDestroy(queueName);
-      // Wait 200ms and check if the queue is correctly deleted in RabbitMQ using a passive queue.
-      setTimeout(function() {
-        smartrouter.amqp.queue(queueName, { passive: true }, function(q) {
-        })
-        .on('error', function() {
-          logger.debug('Queue ' + queueName + ' does not exists anymore');
-          done();
-        });
-      }, 200);
-    });
-  });
-
   describe('nagios responses', function ()
   {
     it('should return a single OK event', function (done)

--- a/test/smartrouter_test.js
+++ b/test/smartrouter_test.js
@@ -320,6 +320,49 @@ describe('Smartrouter tests.', function ()
     });
   });
 
+  it('should set client queue as markedForDeletion after client disconnect', function (done)
+  {
+    logger.debug('********************************************************************');
+    logger.debug('STARTING TEST "Mark actor queues for deletion after they disconnect"');
+    logger.debug('********************************************************************');
+    var mockedAgent = new Agent('http://localhost:' + config.port.toString(), 'agent/456', 'agent456', clientsParams);
+    var mockedUI = new UI('http://localhost:' + config.port.toString(), 'ui/456', 'ui456', clientsParams);
+    mockedAgent.connect();
+    mockedUI.connect();
+    mockedUI.socket.once('disconnect', function () // clients are disconnected automatically after 200ms
+    {
+      // We wait 200ms to be sure we have unsubscribed from RabbitMQ and we test which queue is marked for deletion.
+      setTimeout(function() {
+        console.log(smartrouter._queuesMarkedForDeletion);
+        assert.isDefined(smartrouter._queuesMarkedForDeletion['ui/456/ui456']);
+        assert.isUndefined(smartrouter._queuesMarkedForDeletion['agent/456/agent456']); // Endpoints queues are not deleted.
+        done();
+      }, 200);
+    });
+  });
+
+  it('should delete a queue in RabbitMQ', function (done)
+  {
+    logger.debug('******************************************');
+    logger.debug('STARTING TEST "Delete a Queue in RabbitMQ"');
+    logger.debug('******************************************');
+    var queueName = 'test_queue';
+    smartrouter.amqp.queue(queueName, { autoDelete: false, closeChannelOnUnsubscribe: true }, function (q) {
+    })
+    .on('open', function() {
+      smartrouter.queueDestroy(queueName);
+      // Wait 200ms and check if the queue is correctly deleted in RabbitMQ using a passive queue.
+      setTimeout(function() {
+        smartrouter.amqp.queue(queueName, { passive: true }, function(q) {
+        })
+        .on('error', function() {
+          logger.debug('Queue ' + queueName + ' does not exists anymore');
+          done();
+        });
+      }, 200);
+    });
+  });
+
   describe('nagios responses', function ()
   {
     it('should return a single OK event', function (done)


### PR DESCRIPTION
The first commit is about handling the following case:
- Restart HAProxy
- Sockets are disconnected, smart-router tries to unsubscribe from queues. It fails because connection to RabbitMQ is closed.
- HAProxy is restarted, smart-router is reconnected:
  - sockets are reconnected, they reconnect to the Queue and resubscribe
  - amqp handle the reconnection, and since our unsubscribe has failed, it resubscribe to the queues it has in memory
  - --> we have multiple consumers for a queue.

The second commit is about adding a cron task which delete queues which don't have any connected actors since some time.
Each time we unsubscribe from a queue, I check how many actors are still active. When the last actor unsubscribe, I mark the queue as delete and I destroy it few minutes later if the actor has not reconnected.
