### PR TITLE
Configurable loggers (on/off) + rolling files for File Transport

### DIFF
--- a/config/development.yaml
+++ b/config/development.yaml
@@ -1,6 +1,10 @@
 log:
     level: 'trace'
+    consoleLogger: false
+    fileLogger: true
     filename: 'smart-router.log'
+    maxSize: 50000000
+    maxFiles: 10
 nagios:
     maximumNumberOfEventsToKeep: 100
 https:

--- a/util/logger.js
+++ b/util/logger.js
@@ -38,24 +38,31 @@ var customLevels = {
   }
 };
 
-var logger = winston.loggers.add('logger', {
-  transports: [
-    new (winston.transports.Console)(
-        {
-          level: CONFIG.level,
-          colorize: tty.isatty(process.stdout.fd),
-          json: false,
-          timestamp: true
-        }
-    ),
-    new (winston.transports.File)(
-        {
-          level: CONFIG.level,
-          filename: CONFIG.filename,
-          json: false
-        })
-  ]
-});
+console.log("Enabled loggers: Console=" + CONFIG.consoleLogger + ", File=" + CONFIG.fileLogger);
+var transports = [];
+if (CONFIG.consoleLogger) {
+  transports.push(new (winston.transports.Console)(
+    {
+      level: CONFIG.level,
+      colorize: tty.isatty(process.stdout.fd),
+      json: false,
+      timestamp: true
+    }
+  ));
+}
+if (CONFIG.fileLogger) {
+  transports.push(new (winston.transports.File)(
+    {
+      level: CONFIG.level,
+      filename: CONFIG.filename,
+      json: false,
+      maxsize:CONFIG.maxSize,
+      maxFiles:CONFIG.maxFiles
+    }
+  ));
+}
+
+var logger = winston.loggers.add('logger', { transports: transports });
 
 logger.setLevels(customLevels.levels);
 winston.addColors(customLevels.colors);

--- a/util/logger.js
+++ b/util/logger.js
@@ -17,7 +17,7 @@
 
 var winston = require('winston'),
     tty = require('tty'),
-    CONFIG = require('config').log;
+    CONFIG = require('config');
 
 // Custom levels and color, more similar to log4j
 // Default level are in npm-config, with DEBUG after INFO, weird
@@ -38,26 +38,26 @@ var customLevels = {
   }
 };
 
-console.log("Enabled loggers: Console=" + CONFIG.consoleLogger + ", File=" + CONFIG.fileLogger);
+console.log("Enabled loggers: Console=" + CONFIG.log.consoleLogger + ", File=" + CONFIG.log.fileLogger);
 var transports = [];
-if (CONFIG.consoleLogger) {
+if (CONFIG.log.consoleLogger) {
   transports.push(new (winston.transports.Console)(
     {
-      level: CONFIG.level,
+      level: CONFIG.log.level,
       colorize: tty.isatty(process.stdout.fd),
       json: false,
       timestamp: true
     }
   ));
 }
-if (CONFIG.fileLogger) {
+if (CONFIG.log.fileLogger) {
   transports.push(new (winston.transports.File)(
     {
-      level: CONFIG.level,
-      filename: CONFIG.filename,
+      level: CONFIG.log.level,
+      filename: CONFIG.log.filename,
       json: false,
-      maxsize:CONFIG.maxSize,
-      maxFiles:CONFIG.maxFiles
+      maxsize:CONFIG.log.maxSize,
+      maxFiles:CONFIG.log.maxFiles
     }
   ));
 }


### PR DESCRIPTION
This will permit to have automated rolling file and to keep the Console output redirected in a separated file, in case some uncaught error occurs.
