### PR TITLE
Manage multiple AMQP connection because of how node-amqp is implemented.

### DIFF
--- a/config/development.yaml
+++ b/config/development.yaml
@@ -10,3 +10,4 @@ https:
 
 rabbitmqReconnectDelay: 10000
 delayBeforeDeletingInactiveQueue: 900000
+maxChannelPerConnection: 64000

--- a/lib/smartrouter.js
+++ b/lib/smartrouter.js
@@ -36,7 +36,7 @@ module.exports = new JS.Class(EventEmitter, {
     this.config = {};
     // Keep references of all opened connections (We need multiple connections because each is limited to 65536 channels)
     this.amqpConnections = [];
-    this.MAX_CHANNEL_PER_CONNECTION = 65000;
+    this.MAX_CHANNEL_PER_CONNECTION = CONFIG.maxChannelPerConnection || 64000;
     /**
     * Holds the Nagios responses we return for the next check.  Is replaced after each Nagios check.
     */
@@ -59,6 +59,7 @@ module.exports = new JS.Class(EventEmitter, {
     logger.info(util.format('Starting SmartRouter... Will listen on port %s', config.port));
     logger.info(util.format('Using https: %s', CONFIG.https.use));
     logger.info(util.format('RabbitMQ url is set to %s', config.amqp.url));
+    logger.debug('Max Channel per RabbitMQ Connection: ', this.MAX_CHANNEL_PER_CONNECTION);
     var self = this;
     self.config = config;
     self.reconnectDelay = CONFIG.rabbitmqReconnectDelay || 10000;
@@ -95,9 +96,11 @@ module.exports = new JS.Class(EventEmitter, {
     self.io.server.close();
     self.io.server.once('close', function () {
       logger.debug('socket server closed');
-      self.amqpConnections.forEach(function(amqp) {
-        amqp.end();
-      });
+      setTimeout(function() {
+        self.amqpConnections.forEach(function(amqp) {
+          amqp.end();
+        });
+      }, 100); // Let time to the clients' queues to unsubscribe from RabbitMQ
     });
     var lastConnection = self.amqpConnections[self.amqpConnections.length - 1];
     lastConnection.once('close', function () {
@@ -435,9 +438,11 @@ module.exports = new JS.Class(EventEmitter, {
 
     // length - 1: We always keep the last connection since messages can still arrive until the new one is ready
     var i = self.amqpConnections.length - 1;
-    while (i-- > 0) {
+    while (--i >= 0) {
       var connection = self.amqpConnections[i];
-      if (Object.keys(connection.queues).length == 0) {
+      var queuesNumber = Object.keys(connection.queues).length;
+      logger.debug(util.format("Status of connection [%d]: %d existing queues", i, queuesNumber));
+      if (queuesNumber == 0) {
         logger.info("Closing a connection with no more Queues");
         connection.manuallyClosed = true; // Don't try to reconnect
         connection.end();
@@ -446,7 +451,7 @@ module.exports = new JS.Class(EventEmitter, {
     }
 
     self.amqpConnections.push(amqp);
-    logger.debug("Number of active connections: " + self.amqpConnections.length);
+    logger.debug("New number of active connections: " + self.amqpConnections.length);
 
     return amqp;
   }

--- a/lib/smartrouter.js
+++ b/lib/smartrouter.js
@@ -34,6 +34,9 @@ module.exports = new JS.Class(EventEmitter, {
     this.io = {};
     this.amqp = {};
     this.config = {};
+    // Keep references of all opened connections (We need multiple connections because each is limited to 65536 channels)
+    this.amqpConnections = [];
+    this.MAX_CHANNEL_PER_CONNECTION = 65000;
     /**
     * Holds the Nagios responses we return for the next check.  Is replaced after each Nagios check.
     */
@@ -58,33 +61,14 @@ module.exports = new JS.Class(EventEmitter, {
     logger.info(util.format('RabbitMQ url is set to %s', config.amqp.url));
     var self = this;
     self.config = config;
+    self.reconnectDelay = CONFIG.rabbitmqReconnectDelay || 10000;
     self.delayBeforeDeletingInactiveQueue = CONFIG.delayBeforeDeletingInactiveQueue || (15 * 60 * 1000); // 15min by default
     logger.info('Delay before deleting inactive queues: ' + self.delayBeforeDeletingInactiveQueue);
 
-    var reconnectDelay = CONFIG.rabbitmqReconnectDelay || 10000;
-    self.amqp = Amqp.createConnection(config.amqp, { reconnect: true, reconnectBackoffTime: reconnectDelay });
+    self.amqp = self._createAmqpConnection();
 
-    self.amqp.on('error', function (err) {
-      self.amqpError = true;
-      var errMsg = util.format('Error while connecting to RabbitMQ: %s. Will try to reconnect in %s', err, reconnectDelay);
-      logger.error(errMsg);
-      self._storeNagiosEvent(new NagiosCheckResponse(NagiosCheckResponseCodes.ERROR, EVENTS_CONTROLLER_SUBSYSTEM, errMsg));
-      //Emit an error on the socket for the client.
-      self.emit('amqpError', new Error(errMsg));
-    });
-    self.amqp.on('ready', function() {
-      self.amqpError = false;
-      if (self.started) {
-        logger.info(util.format('Reconnected to RabbitMQ at %s', config.amqp.url));
-        // If we were trying to do some unsubscriptions before the error occurred, do them now.
-        self._consumersWaitingForUnsubscription.forEach(function(item) {
-          logger.info('Reconnection: Retrying to Unsubscribe from queue ' + item.queue.name + ' for consumer=' + item.ctag);
-          item.queue.unsubscribe(item.ctag);
-        });
-        return; // We already started the socket.io server, returning.
-      }
-
-      logger.info(util.format('Connected to RabbitMQ at %s. Starting Socket.IO server...', config.amqp.url));
+    self.amqp.once('ready', function() {
+      logger.info('Starting Socket.IO server...');
       if (CONFIG.https.use) {
         var options = {
           pfx: fs.readFileSync(CONFIG.https.pfx_path),
@@ -101,18 +85,6 @@ module.exports = new JS.Class(EventEmitter, {
       self.started = true;
       self.emit('started');
     });
-    self.amqp.on('close', function() {
-      logger.info('Connection to RabbitMQ closed.');
-      // AMQP backoff strategy only works in case an error has occurred.
-      // So if amqp has already emitted an error, we don't try to reconnect. It is handled by amqp backoff mechanism.
-      // But in case of a HAProxy timeout, we just receive a 'close' event without any error. We don't
-      // want to wait for a future error (i.e. a client trying to send a message), because we could lose some data.
-      if (self.started && !self.amqpError)
-      {
-        logger.info('SmartRouter is still running. Trying to reconnect to RabbitMQ.');
-        self.amqp.reconnect();
-      }
-    });
   },
 
   stop: function()
@@ -123,9 +95,12 @@ module.exports = new JS.Class(EventEmitter, {
     self.io.server.close();
     self.io.server.once('close', function () {
       logger.debug('socket server closed');
-      self.amqp.end();
+      self.amqpConnections.forEach(function(amqp) {
+        amqp.end();
+      });
     });
-    self.amqp.once('close', function () {
+    var lastConnection = self.amqpConnections[self.amqpConnections.length - 1];
+    lastConnection.once('close', function () {
       self.emit('stopped');
     });
   },
@@ -312,6 +287,10 @@ module.exports = new JS.Class(EventEmitter, {
         });
       });
     });
+
+    if (this.amqp.channelCounter >= self.MAX_CHANNEL_PER_CONNECTION && !self.creatingAmqpConnection) {
+      self._createAmqpConnection();
+    }
   },
 
   /**
@@ -405,5 +384,70 @@ module.exports = new JS.Class(EventEmitter, {
       }
       self.amqp.publish(destactorid, qmsg, { contentType: 'application/json' });
     });
+
+    if (this.amqp.channelCounter >= self.MAX_CHANNEL_PER_CONNECTION && !self.creatingAmqpConnection) {
+      self._createAmqpConnection();
+    }
+  },
+
+  _createAmqpConnection: function() {
+    var self = this;
+    self.creatingAmqpConnection = true;
+
+    logger.info(util.format('Opening connection to RabbitMQ at %s.', self.config.amqp.url));
+    var amqp = Amqp.createConnection(self.config.amqp, { reconnect: true, reconnectBackoffTime: self.reconnectDelay });
+
+    amqp.on('error', function (err) {
+      self.amqpError = true;
+      var errMsg = util.format('Error while connecting to RabbitMQ: %s. Will try to reconnect in %s', err, self.reconnectDelay);
+      logger.error(errMsg);
+      self._storeNagiosEvent(new NagiosCheckResponse(NagiosCheckResponseCodes.ERROR, EVENTS_CONTROLLER_SUBSYSTEM, errMsg));
+      //Emit an error on the socket for the client.
+      self.emit('amqpError', new Error(errMsg));
+    });
+    amqp.once('ready', function() {
+      self.amqp = amqp;
+      self.creatingAmqpConnection = false;
+    });
+    amqp.on('ready', function() {
+      self.amqpError = false;
+      logger.info(util.format('Connected to RabbitMQ at %s', self.config.amqp.url));
+      if (self.started) {
+        // If we were trying to do some unsubscriptions before the error occurred, do them now.
+        self._consumersWaitingForUnsubscription.forEach(function(item) {
+          logger.info('Reconnection: Retrying to Unsubscribe from queue ' + item.queue.name + ' for consumer=' + item.ctag);
+          item.queue.unsubscribe(item.ctag);
+        });
+      }
+    });
+    amqp.on('close', function() {
+      logger.info('Connection to RabbitMQ closed.');
+      // AMQP backoff strategy only works in case an error has occurred.
+      // So if amqp has already emitted an error, we don't try to reconnect. It is handled by amqp backoff mechanism.
+      // But in case of a HAProxy timeout, we just receive a 'close' event without any error. We don't
+      // want to wait for a future error (i.e. a client trying to send a message), because we could lose some data.
+      if (!amqp.manuallyClosed && self.started && !self.amqpError)
+      {
+        logger.info('SmartRouter is still running. Trying to reconnect to RabbitMQ.');
+        amqp.reconnect();
+      }
+    });
+
+    // length - 1: We always keep the last connection since messages can still arrive until the new one is ready
+    var i = self.amqpConnections.length - 1;
+    while (i-- > 0) {
+      var connection = self.amqpConnections[i];
+      if (Object.keys(connection.queues).length == 0) {
+        logger.info("Closing a connection with no more Queues");
+        connection.manuallyClosed = true; // Don't try to reconnect
+        connection.end();
+        self.amqpConnections.splice(i, 1);
+      }
+    }
+
+    self.amqpConnections.push(amqp);
+    logger.debug("Number of active connections: " + self.amqpConnections.length);
+
+    return amqp;
   }
 });

--- a/lib/smartrouter.js
+++ b/lib/smartrouter.js
@@ -305,7 +305,17 @@ module.exports = new JS.Class(EventEmitter, {
     socket.get('queueData', function (err, queueData) {
       if (queueData) {
         queueData.forEach(function (item) {
-          self._consumersWaitingForUnsubscription.push(item);
+          // node-amqp behaviour in case of a proxy restart (a proxy between clients, smart-router and RabbitMQ):
+          // - All Clients are disconnected, so we trigger many unsubscriptions
+          // - 1 by 1, node-amqp put the tasks in its tasksQueue and run them
+          // - At some point, node-amqp is aware of the disconnection
+          // - The already run tasks are lost. Those still in the queue or those queued after will be run at reconnection.
+          // So we only need to monitor the unsubscriptions which are triggered while the queue is open, they are the
+          // ones that can be lost.
+          logger.debug(util.format('Unsubscribing from queue %s (%s)', item.queue.name, item.queue.state));
+          if (item.queue.state == 'open') {
+            self._consumersWaitingForUnsubscription.push(item);
+          }
           item.queue.unsubscribe(item.ctag).addCallback(function () {
             logger.info(util.format('Unsubscribed from Queue [%s] for socket %s ; consumerTag=%s', item.queue.name, socket.id, item.ctag));
             for (var i = 0; i < self._consumersWaitingForUnsubscription.length; ++i) {
@@ -413,15 +423,17 @@ module.exports = new JS.Class(EventEmitter, {
       self.creatingAmqpConnection = false;
     });
     amqp.on('ready', function() {
-      self.amqpError = false;
       logger.info(util.format('Connected to RabbitMQ at %s', self.config.amqp.url));
-      if (self.started) {
+      if (self.started && self.amqpError) { // Retry the unsubscription only once even if there are several connections
         // If we were trying to do some unsubscriptions before the error occurred, do them now.
-        self._consumersWaitingForUnsubscription.forEach(function(item) {
-          logger.info('Reconnection: Retrying to Unsubscribe from queue ' + item.queue.name + ' for consumer=' + item.ctag);
-          item.queue.unsubscribe(item.ctag);
-        });
+        setTimeout(function () {
+          self._consumersWaitingForUnsubscription.forEach(function(item) {
+            logger.info('Reconnection: Retrying to Unsubscribe from queue ' + item.queue.name + ' for consumer=' + item.ctag);
+            item.queue.unsubscribe(item.ctag);
+          });
+        }, 500); // let time to node-amqp to do the unsubscription itself, if the task is queued.
       }
+      self.amqpError = false;
     });
     amqp.on('close', function() {
       logger.info('Connection to RabbitMQ closed.');
@@ -438,6 +450,9 @@ module.exports = new JS.Class(EventEmitter, {
 
     // length - 1: We always keep the last connection since messages can still arrive until the new one is ready
     var i = self.amqpConnections.length - 1;
+    if (i >= 0) {
+      logger.debug(util.format("Status of connection [%d]: %d existing queues", i, Object.keys(self.amqpConnections[i].queues).length));
+    }
     while (--i >= 0) {
       var connection = self.amqpConnections[i];
       var queuesNumber = Object.keys(connection.queues).length;

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "jsclass": "3.0.9",
-    "amqp": "git+ssh://git@github.com:VirtuOz/node-amqp.git#fixReconnectAndPassiveQueues",
+    "amqp": "git+https://github.com/VirtuOz/node-amqp.git#fixReconnectAndPassiveQueues",
     "socket.io": "0.9",
     "socket.io-client": "0.9",
     "winston": "0.6.2",

--- a/test/smartrouter_test.js
+++ b/test/smartrouter_test.js
@@ -230,6 +230,7 @@ describe('Smartrouter tests.', function ()
     setTimeout(function ()
                {
                  mockedAgent.connect();
+                 mockedUI.connect(); // Read the automatic Agent's response in order to empty RabbitMQ queue.
                  mockedAgent.socket.once('talk', function (data)
                  {
                    // Message has been kept waiting for agent to connect
@@ -272,6 +273,7 @@ describe('Smartrouter tests.', function ()
       smartrouter.io.set('client store expiration', .2);
       logger.info('SmartRouter restarted. Connecting the agent to it');
       mockedAgent.connect();
+      mockedUI.connect(); // Will read/clean the RabbitMQ queue for next tests (Mocked Agent automatically sends a response).
       // We should receive the message sent by the UI before the shutdown
       mockedAgent.socket.once('talk', function (data)
       {
@@ -305,52 +307,59 @@ describe('Smartrouter tests.', function ()
     mockedAgent.socket.once('talk', function (data)
     {
       assert.equal(2, smartrouter.amqpConnections.length, "Number of connection after first talk received from UI");
-      assert.equal(0, smartrouter.amqp.channelCounter, "Number of channels on 2nd Connection");
       assert.equal('This message will create a channel', data.payload.text);
       // This 'talk' event will trigger a response from the agent, which will open 2 channels
       // on the 2nd connection (the queue + the default exchange)
     });
 
-    mockedUI.socket.once('talkback', function ()
+    mockedUI.socket.once('talkback', function (data)
     {
       assert.equal(2, smartrouter.amqp.channelCounter, "channelCounter of 2nd Connection after receiving talkback from agent");
       // After the agent response, we talk again: 1 new channel for this message +
-      // another for the agent response = 4 channels on the 2nd connection -> new Channel
+      // another for the agent response = 4 channels on the 2nd connection -> new Connection (the 3rd)
       mockedUI.talk('This message will create another channel');
 
       mockedUI.socket.once('talkback', function(data) {
-        assert.equal(3, smartrouter.amqpConnections.length, "Number of connection after second talk finished");
-        for (var i = 0; i < smartrouter.amqpConnections.length; ++i) {
-          logger.debug('Queues for connection ' + i + ': ' + Object.keys(smartrouter.amqpConnections[i].queues));
-        }
-
-        // We disconnect the firsts clients so that all queues are deleted from the 1st connection and 2nd connection.
-        // In practice, only the 1st connection is cleaned, I don't know why. Certainly because we are in a single process.
-        // Works fine with real clients.
-        mockedUI.socket.disconnect();
-        mockedAgent.socket.disconnect();
-        // We connect new clients. It will create 3 queues on the 3rd connection
-        var mockedAgent_2 = new Agent('http://localhost:' + config.port.toString(), 'agent/456', 'agent456', clientsParams);
-        var mockedUI_2 = new UI('http://localhost:' + config.port.toString(), 'ui/456', 'ui456', clientsParams);
-        mockedAgent_2.connect();
-        mockedUI_2.connect();
+        // Second agent response received
         setTimeout(function () {
+          assert.equal(3, smartrouter.amqpConnections.length, "Number of connection after second talk finished");
+          assert.equal(0, smartrouter.amqp.channelCounter, "Number of channels on 3rd Connection");
+
           for (var i = 0; i < smartrouter.amqpConnections.length; ++i) {
             logger.debug('Queues for connection ' + i + ': ' + Object.keys(smartrouter.amqpConnections[i].queues));
           }
 
-          // We talk to create new channels on the 3rd connection and make the smart-router create a new one.
-          // It will also clean the empty connections (so the 1st)
-          mockedUI_2.talk('Another talk from another UI');
-          mockedUI_2.socket.once('talkback', function(data) {
-            // Agent has replied. In the meantime, smart-router has cleaned the empty connection.
-            assert.equal(3, smartrouter.amqpConnections.length, "Number of connection at the end");
-            done();
-          });
-        }, 100);
+          // We disconnect the firsts clients so that all queues are deleted from the 1st connection and 2nd connection.
+          mockedUI.socket.disconnect();
+          mockedAgent.socket.disconnect();
+          continueMultipleConnectionTestWithNewClients(done);
+        }, 50);
       });
     });
   });
+
+  function continueMultipleConnectionTestWithNewClients(done)
+  {
+    // We connect new clients. It will create 3 queues on the 3rd connection
+    var mockedAgent_2 = new Agent('http://localhost:' + config.port.toString(), 'agent/456', 'agent456', clientsParams);
+    var mockedUI_2 = new UI('http://localhost:' + config.port.toString(), 'ui/456', 'ui456', clientsParams);
+    mockedAgent_2.connect();
+    mockedUI_2.connect();
+    setTimeout(function () {
+      for (var i = 0; i < smartrouter.amqpConnections.length; ++i) {
+        logger.debug('Queues for connection ' + i + ': ' + Object.keys(smartrouter.amqpConnections[i].queues));
+      }
+
+      // We talk to create new channels on the 3rd connection and make the smart-router create a new one (4th).
+      // It will also clean the empty connections (so the two firsts. We have 2 connections remaining)
+      mockedUI_2.talk('Another talk from another UI');
+      mockedUI_2.socket.once('talkback', function(data) {
+        // Agent has replied. In the meantime, smart-router has cleaned the empty connection.
+        assert.equal(2, smartrouter.amqpConnections.length, "Number of connection at the end");
+        done();
+      });
+    }, 100);
+  }
 
   // We will try to connect on an undefined endpoint (/agent/458).
   // As it is not registered, we will not receive the handshake and will be disconnected (timeout = 200ms).


### PR DESCRIPTION
After 65536 channels on a connection, it won't work anymore, so we create a new connection before that happen.
And we remove the unused connections.
