### PR TITLE
Prevent config errors: NODE_CONFIG_DIR not set and no config/ directory,...

### DIFF
--- a/lib/actor.js
+++ b/lib/actor.js
@@ -68,6 +68,9 @@ module.exports = new JS.Class({
   log: function (msg) {
     logger.info('[' + this.actorid + ']: ' + msg);
   },
+  debug: function (msg) {
+    logger.debug('[' + this.actorid + ']: ' + msg);
+  },
   error: function (msg) {
     logger.error('[' + this.actorid + ']: ' + msg);
   },

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,6 +8,17 @@
  * @created 2012-10-24
  */
 
+var fs = require('fs');
+
+if (!process.env.NODE_CONFIG_DIR && !fs.existsSync(process.cwd() + '/config')) {
+  var tmpDir = require('os').tmpDir() + '/smartrouter';
+  console.warn('NODE_CONFIG_DIR is not set. Using default directory: ' + tmpDir);
+  if (!fs.existsSync(tmpDir)) {
+    fs.mkdirSync(tmpDir);
+  }
+  process.env.NODE_CONFIG_DIR = tmpDir;
+}
+
 exports.SmartRouter = require('./smartrouter');
 exports.Actor = require('./actor');
 exports.const = require('./const');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smart-router",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "author": "Callixte <ccauchois@virtuoz.com>",
   "description": "a message routing system that routes messages based on their content.",
   "main": "./lib/index",

--- a/util/logger.js
+++ b/util/logger.js
@@ -38,6 +38,10 @@ var customLevels = {
   }
 };
 
+if (!CONFIG.log) {
+  console.warn("CONFIG.log properties are not defined, activating console by default (level will be INFO).");
+  CONFIG.log = { consoleLogger: true, fileLogger: false };
+}
 console.log("Enabled loggers: Console=" + CONFIG.log.consoleLogger + ", File=" + CONFIG.log.fileLogger);
 var transports = [];
 if (CONFIG.log.consoleLogger) {


### PR DESCRIPTION
... or CONFIG.log undefined

I figured out during while creating a connector in vnodelib that if the environment is not correctly set, the process will crash. This will permit to run a smart-router actor without having to setup the CONFIG env.
